### PR TITLE
Remove jackson-mapper-asl dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -963,11 +963,6 @@
                 <version>${codehaus.jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>${codehaus.jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>


### PR DESCRIPTION
Jackson-Mapper-ASL includes vulnerabilities highlighted here: https://github.com/advisories/GHSA-r6j9-8759-g62w
A Hadoop dependency, it is not required for the nets-aric implementation of Druid.
